### PR TITLE
fix key value for cloud cdn to issue signed urls

### DIFF
--- a/mmv1/templates/terraform/examples/backend_bucket_signed_url_key.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_bucket_signed_url_key.tf.erb
@@ -4,7 +4,7 @@ resource "random_id" "url_signature" {
 
 resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
   name           = "<%= ctx[:vars]['key_name'] %>"
-  key_value      = random_id.url_signature.b64_url
+  key_value      = replace(replace(random_id.url_signature.b64_std,"+", "-") ,"/", "_")
   backend_bucket = google_compute_backend_bucket.test_backend.name
 }
 

--- a/mmv1/templates/terraform/examples/backend_service_signed_url_key.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_service_signed_url_key.tf.erb
@@ -4,7 +4,7 @@ resource "random_id" "url_signature" {
 
 resource "google_compute_backend_service_signed_url_key" "backend_key" {
   name            = "<%= ctx[:vars]['key_name'] %>"
-  key_value       = random_id.url_signature.b64_url
+  key_value       = replace(replace(random_id.url_signature.b64_std,"+", "-") ,"/", "_")
   backend_service = google_compute_backend_service.example_backend.name
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixed key value for cloud cdn to issue signed urls.

When creating a signed URL for CloudCDN, I used  `random_id b64_url`.
[google_compute_backend_bucket_signed_url_key | Resources | hashicorp/google | Terraform Registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_bucket_signed_url_key)
```terraform
resource "random_id" "url_signature" {
  byte_length = 16
}

resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
  name           = "test-key"
  key_value      = random_id.url_signature.b64_url
  backend_bucket = google_compute_backend_bucket.test_backend.name
}
```
I have confirmed that this works.
However, when I created them from the Google Cloud console or `gcloud` commanda, the keys created were URL safe, base64 encoded, and **_padded with `=`_**.

Furthermore, the official Google Cloud sample code assumes padded keys, so I could not use the keys created with `b64_url` without modification. In addition, when I tried to create a signed URL using the `gcloud compute sign-url` command, an error occurred because it used a key without padding.

failed gcloud command
```sh
> gcloud compute sign-url \
  "https://example.com/test.png" \
  --key-name test-key \
  --key-file key-file \
  --expires-in 5m \
  --validate
ERROR: gcloud crashed (Error): Incorrect padding

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
```

fixed google cloud sample code for golang
[Use signed URLs  |  Cloud CDN  |  Google Cloud](https://cloud.google.com/cdn/docs/using-signed-urls?hl=en#gcloud_1)
```diff
// readKeyFile reads the base64url-encoded key file and decodes it.
func readKeyFile(path string) ([]byte, error) {
        b, err := ioutil.ReadFile(path)
        if err != nil {
                return nil, fmt.Errorf("failed to read key file: %+v", err)
        }
-       d := make([]byte, base64.URLEncoding.DecodedLen(len(b)))
-       n, err := base64.URLEncoding.Decode(d, b)
+       d := make([]byte, base64.RawURLEncoding.DecodedLen(len(b)))
+       n, err := base64.RawURLEncoding.Decode(d, b)
        if err != nil {
                return nil, fmt.Errorf("failed to base64url decode: %+v", err)
        }
        return d[:n], nil
}

```

Therefore, for Cloud CDN key values, base64 url safe and padding with `=` is desirable, but currently random_id does not provide such output. One of the outputs of random_id, ` b64_std`, is not url safe, but it is base64 encoded with `=` padding. So I modified the code to take advantage of this and use the `replace` function to convert it to url safe.

```terraform
key_value       = replace(replace(random_id.url_signature.b64_std,"+", "-") ,"/", "_")
```

I have confirmed by looking at the implementation in the random_id repository ([hashicorp/terraform-provider-random](https://github.com/hashicorp/terraform-provider-random) ) that `b64_url` and `b64_std` implemented in Go as follows

https://github.com/hashicorp/terraform-provider-random/blob/7b934142db2bb3569fa324df4409bb6c6dc69ec3/internal/provider/resource_id.go#L143-L161
```go
b64Std := base64.StdEncoding.EncodeToString(bytes)
id := base64.RawURLEncoding.EncodeToString(bytes)
...
B64URL:     types.StringValue(prefix + id),
```

I think that `base64.URLEncoding.EncodeToString(bytes)` is suitable in this case, not `base64.RawURLEncoding.EncodeToString(bytes)`.
So I think that we need to add the output to `random_id`.(ActuallyI have issued a PR regarding this.)



---
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME
Fix key value for cloud cdn to issue signed urls
```
